### PR TITLE
Fixing call to deprecated method

### DIFF
--- a/jquery.scrollstop.js
+++ b/jquery.scrollstop.js
@@ -14,7 +14,7 @@
                 clearTimeout(timer);
               } else {
                 evt.type = 'scrollstart';
-                $.event.handle.apply(_self, _args);
+                $.event.dispatch.apply(_self, _args);
               }
 
               timer = setTimeout(function() {
@@ -44,7 +44,7 @@
               timer = setTimeout(function() {
                 timer = null;
                 evt.type = 'scrollstop';
-                $.event.handle.apply(_self, _args);
+                $.event.dispatch.apply(_self, _args);
               }, special.scrollstop.latency);
             };
 


### PR DESCRIPTION
Changed _event.handle_ calls to _event.dispatch_.
_event.handle_ was deprecated in jQuery 1.7, and removed in jQuery 1.9
